### PR TITLE
Add web3signer gnosis as an optional dependency

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -40,6 +40,9 @@
   "warnings": {
     "onRemove": "Make sure your StakersUI does not have this client selected! Double check in the Stakers Tab in the left NavBar"
   },
+  "optionalDependencies": {
+    "web3signer-gnosis.dnp.dappnode.eth": "1.0.10"
+  },
   "globalEnvs": [
     {
       "envs": ["EXECUTION_CLIENT_GNOSIS"],


### PR DESCRIPTION
Web3Signer gnosis version must be >= `1.0.10` in order to include `nimbus-gnosis.dnp.dappnode.eth` as an available consensus client